### PR TITLE
Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       
       # ouch - unless and until we start using CMake's install command, these next few steps are a necessary evil
       - name: Organize binaries
-        run: mkdir packaged && find build -perm /a+x -exec mv {} packaged \;
+        run: mkdir packaged && mv build/RNR.* packaged
 
       - name: Add RNR resources
         run: cp -R Content/RNR packaged/content && cp LICENSE packaged

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           runVcpkgInstall: true
+          vcpkgGitCommitId: 9d47b24 # hardcoded because the idiot who made this action didn't make it possible to use the latest commit by default
           vcpkgDirectory: ${{ github.workspace }}/vcpkg
 
       - name: Generate Ninja build files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,69 @@ name: Build
 on: [ push ]
 
 jobs:
+  linux:
+    strategy:
+      matrix:
+        configuration: [ Release, Debug ]
+    
+    name: Linux
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install required packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          version: 5.0
+          packages: >-
+            build-essential
+            cmake
+            ninja-build
+            libboost-all-dev
+            libogre-1.12-dev
+            libpugixml-dev
+        
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: 6.*
+          cache: true
+        
+      - name: Generate Ninja build files
+        run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} .
+      
+      - name: Run Ninja build
+        run: ninja -C build
+      
+      # ouch - unless and until we start using CMake's install command, these next few steps are a necessary evil
+      - name: Organize binaries
+        run: mkdir build/dist && find build -perm /a+x -exec mv {} build/dist \;
+
+      - name: Add RNR resources
+        run: cp -R Content/RNR build/dist/content && cp LICENSE build/dist
+
+      - name: Add OGRE plugins
+        run: cp -R build/plugins build/dist && cp Content/linux_plugins.cfg build/dist/plugins.cfg
+      
+      - name: Add OGRE shaders
+        run: cp -R build/shaders build/dist
+
+      - name: Set output variables
+        id: vars
+        run: |
+          echo "configuration=${{ matrix.configuration }}" | awk '{print tolower($0)}' >> $GITHUB_OUTPUT
+          echo "hash=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: rnr-${{ steps.vars.outputs.hash }}-linux_x64-${{ steps.vars.outputs.configuration }}
+          path: build/dist
+  
   windows:
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,21 +19,11 @@ jobs:
       - name: Install required packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          version: 1.0.1
+          version: 1.0.2
           packages: >-
             build-essential
             cmake
             ninja-build
-            libboost-all-dev
-            libgles2-mesa-dev
-            libvulkan-dev
-            glslang-dev
-            libxrandr-dev
-            libsdl2-dev
-            libxt-dev
-            libxaw7-dev
-            libpugixml-dev
-            libbullet-dev
         
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
@@ -41,11 +31,14 @@ jobs:
           version: 6.*
           cache: true
       
-      - name: Install Ogre
-        run: git clone https://github.com/OGRECave/ogre && cd ogre && cmake --configure . && cmake --build . --config Release --target install && cd ../
-        
+      - name: Install vcpkg
+        run: git clone https://github.com/Microsoft/vcpkg.git && ./vcpkg/bootstrap-vcpkg.sh && ./vcpkg/vcpkg integrate install
+      
+      - name: Install development packages via vcpkg
+        run: ./vcpkg/vcpkg install ogre3d:x64-linux bullet3:x64-linux boost:x64-linux pugixml:x64-linux 
+
       - name: Generate Ninja build files
-        run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} .
+        run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake  .
       
       - name: Run Ninja build
         run: ninja -C build
@@ -103,12 +96,12 @@ jobs:
             mingw-w64-${{ matrix.env }}-${{ matrix.sys == 'clang64' && 'clang' || 'gcc' }}
             mingw-w64-${{ matrix.env }}-cmake
             mingw-w64-${{ matrix.env }}-ninja
+            mingw-w64-${{ matrix.env }}-ogre3d
+            mingw-w64-${{ matrix.env }}-bullet
+            mingw-w64-${{ matrix.env }}-qt6
             mingw-w64-${{ matrix.env }}-boost
             mingw-w64-${{ matrix.env }}-pugixml
-            mingw-w64-${{ matrix.env }}-ogre3d
-            mingw-w64-${{ matrix.env }}-qt6
-            mingw-w64-${{ matrix.env }}-bullet
-      
+            
       - name: Generate Ninja build files
         run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} .
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           version: 1.0.1
           packages: >-
-            git
             build-essential
             cmake
             ninja-build
@@ -43,7 +42,7 @@ jobs:
           cache: true
       
       - name: Install Ogre
-        run: git clone https://github.com/OGRECave/ogre && cd ogre && cmake --configre . && cmake --build . --config Release --target install && cd ../
+        run: git clone https://github.com/OGRECave/ogre && cd ogre && cmake --configure . && cmake --build . --config Release --target install && cd ../
         
       - name: Generate Ninja build files
         run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           runVcpkgInstall: true
-          vcpkgGitCommitId: 9d47b24 # hardcoded because the idiot who made this action didn't make it possible to use the latest commit by default
+          vcpkgGitCommitId: 9d47b24eacbd1cd94f139457ef6cd35e5d92cc84 # hardcoded because the idiot who made this action didn't make it possible to use the latest commit by default
           vcpkgDirectory: ${{ github.workspace }}/vcpkg
 
       - name: Generate Ninja build files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,20 +19,31 @@ jobs:
       - name: Install required packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          version: 5.0
+          version: 1.0.1
           packages: >-
+            git
             build-essential
             cmake
             ninja-build
             libboost-all-dev
-            libogre-1.12-dev
+            libgles2-mesa-dev
+            libvulkan-dev
+            glslang-dev
+            libxrandr-dev
+            libsdl2-dev
+            libxt-dev
+            libxaw7-dev
             libpugixml-dev
+            libbullet-dev
         
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
           version: 6.*
           cache: true
+      
+      - name: Install Ogre
+        run: git clone https://github.com/OGRECave/ogre && cd ogre && cmake --build . --config Release --target install
         
       - name: Generate Ninja build files
         run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install required packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          version: 1.0.5
+          version: 1.1.0
           packages: >-
             build-essential
             cmake
@@ -38,6 +38,7 @@ jobs:
             libxext-dev
             libwayland-dev
             libibus-1.0-dev
+            libraw-dev
       
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
@@ -49,27 +50,27 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           runVcpkgInstall: true
-          vcpkgGitCommitId: 9d47b24eacbd1cd94f139457ef6cd35e5d92cc84 # hardcoded because the idiot who made this action didn't make it possible to use the latest commit by default
+          vcpkgGitCommitId: 9d47b24eacbd1cd94f139457ef6cd35e5d92cc84
           vcpkgDirectory: ${{ github.workspace }}/vcpkg
 
       - name: Generate Ninja build files
-        run: cmake -S . -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
+        run: cmake -S . -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} -DOpenGL_GL_PREFERENCE=GLVND -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
       
       - name: Run Ninja build
         run: ninja -C build
       
       # ouch - unless and until we start using CMake's install command, these next few steps are a necessary evil
       - name: Organize binaries
-        run: mkdir build/dist && find build -perm /a+x -exec mv {} build/dist \;
+        run: mkdir packaged && find build -perm /a+x -exec mv {} packaged \;
 
       - name: Add RNR resources
-        run: cp -R Content/RNR build/dist/content && cp LICENSE build/dist
+        run: cp -R Content/RNR packaged/content && cp LICENSE packaged
 
       - name: Add OGRE plugins
-        run: cp -R build/plugins build/dist && cp Content/linux_plugins.cfg build/dist/plugins.cfg
+        run: cp -R build/plugins packaged && cp Content/linux_plugins.cfg packaged/plugins.cfg
       
       - name: Add OGRE shaders
-        run: cp -R build/shaders build/dist
+        run: cp -R build/shaders packaged && mv packaged/shaders/GLSL/* packaged/shaders && rm -rf packaged/shaders/GLSL
 
       - name: Set output variables
         id: vars
@@ -81,7 +82,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: rnr-${{ steps.vars.outputs.hash }}-linux_x64-${{ steps.vars.outputs.configuration }}
-          path: build/dist
+          path: packaged
   
   windows:
     strategy:
@@ -125,22 +126,22 @@ jobs:
       
       # ouch - unless and until we start using CMake's install command, these next few steps are a necessary evil
       - name: Organize binaries
-        run: mkdir build/dist && mv build/*.exe build/dist
+        run: mkdir packaged && mv build/*.exe packaged
 
       - name: Add RNR resources
-        run: cp -R Content/RNR build/dist/content && cp LICENSE build/dist
+        run: cp -R Content/RNR packaged/content && cp LICENSE packaged
 
       - name: Add Qt plugins and dependencies
-        run: windeployqt6 build/dist/*.exe
+        run: windeployqt6 packaged/*.exe
 
       - name: Add OGRE plugins
-        run: cp Content/win32_plugins.cfg build/dist/plugins.cfg && mkdir build/dist/plugins/ && cat build/dist/plugins.cfg | grep "Plugin=" | sed -e "s/Plugin=//" | xargs -I '{}' cp -v '/${{ matrix.sys }}/bin/{}.dll' build/dist/plugins/
+        run: cp Content/win32_plugins.cfg packaged/plugins.cfg && mkdir packaged/plugins/ && cat packaged/plugins.cfg | grep "Plugin=" | sed -e "s/Plugin=//" | xargs -I '{}' cp -v '/${{ matrix.sys }}/bin/{}.dll' packaged/plugins
       
       - name: Add OGRE shaders
-        run: mkdir build/dist/shaders && cp -R /${{ matrix.sys }}/share/OGRE/Media/Main/* build/dist/shaders && cp -R /${{ matrix.sys }}/share/OGRE/Media/RTShaderLib/* build/dist/shaders && mv build/dist/shaders/GLSL/* build/dist/shaders && rm -rf build/dist/shaders/GLSL
+        run: mkdir packaged/shaders && cp -R /${{ matrix.sys }}/share/OGRE/Media/Main/* packaged/shaders && cp -R /${{ matrix.sys }}/share/OGRE/Media/RTShaderLib/* packaged/shaders && mv packaged/shaders/GLSL/* packaged/shaders && rm -rf packaged/shaders/GLSL
     
       - name: Add additional runtime dependencies
-        run: ldd build/dist/*.exe | grep "=> /" | awk '{print $3}' | grep "${{ matrix.sys }}" | xargs -I '{}' cp -v '{}' build/dist
+        run: ldd packaged/*.exe | grep "=> /${{ matrix.sys }}/" | awk '{print $3}' | xargs -I '{}' cp -v '{}' packaged
       
       - name: Set output variables
         id: vars
@@ -152,4 +153,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: rnr-${{ steps.vars.outputs.hash }}-win_x64-${{ steps.vars.outputs.configuration }}
-          path: build/dist
+          path: packaged

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
             build-essential
             cmake
             ninja-build
+            libxi-dev
       
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,17 +19,25 @@ jobs:
       - name: Install required packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          version: 1.0.3
+          version: 1.0.5
           packages: >-
             build-essential
             cmake
             ninja-build
             libxi-dev
+            libx11-dev
+            libxft-dev
+            libxkbcommon-dev
+            libegl1-mesa-dev
             libgl1-mesa-dev
             libglu1-mesa-dev
             mesa-common-dev
             libxrandr-dev
             libxxf86vm-dev
+            libxaw7-dev
+            libxext-dev
+            libwayland-dev
+            libibus-1.0-dev
       
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
@@ -45,7 +53,7 @@ jobs:
           vcpkgDirectory: ${{ github.workspace }}/vcpkg
 
       - name: Generate Ninja build files
-        run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake  .
+        run: cmake -S . -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
       
       - name: Run Ninja build
         run: ninja -C build
@@ -110,7 +118,7 @@ jobs:
             mingw-w64-${{ matrix.env }}-pugixml
             
       - name: Generate Ninja build files
-        run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} .
+        run: cmake -S . -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }}
       
       - name: Run Ninja build
         run: ninja -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,18 +24,18 @@ jobs:
             build-essential
             cmake
             ninja-build
-        
+      
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
           version: 6.*
           cache: true
       
-      - name: Install vcpkg
-        run: git clone https://github.com/Microsoft/vcpkg.git && ./vcpkg/bootstrap-vcpkg.sh && ./vcpkg/vcpkg integrate install
-      
       - name: Install development packages via vcpkg
-        run: ./vcpkg/vcpkg install ogre:x64-linux bullet3:x64-linux boost:x64-linux pugixml:x64-linux 
+        uses: lukka/run-vcpkg@v11
+        with:
+          runVcpkgInstall: true
+          vcpkgDirectory: ${{ github.workspace }}/vcpkg
 
       - name: Generate Ninja build files
         run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake  .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           cache: true
       
       - name: Install Ogre
-        run: git clone https://github.com/OGRECave/ogre && cd ogre && cmake --build . --config Release --target install && cd ../
+        run: git clone https://github.com/OGRECave/ogre && cd ogre && cmake --configre . && cmake --build . --config Release --target install && cd ../
         
       - name: Generate Ninja build files
         run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,17 @@ jobs:
       - name: Install required packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          version: 1.0.2
+          version: 1.0.3
           packages: >-
             build-essential
             cmake
             ninja-build
             libxi-dev
+            libgl1-mesa-dev
+            libglu1-mesa-dev
+            mesa-common-dev
+            libxrandr-dev
+            libxxf86vm-dev
       
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           cache: true
       
       - name: Install Ogre
-        run: git clone https://github.com/OGRECave/ogre && cd ogre && cmake --build . --config Release --target install
+        run: git clone https://github.com/OGRECave/ogre && cd ogre && cmake --build . --config Release --target install && cd ../
         
       - name: Generate Ninja build files
         run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         run: git clone https://github.com/Microsoft/vcpkg.git && ./vcpkg/bootstrap-vcpkg.sh && ./vcpkg/vcpkg integrate install
       
       - name: Install development packages via vcpkg
-        run: ./vcpkg/vcpkg install ogre3d:x64-linux bullet3:x64-linux boost:x64-linux pugixml:x64-linux 
+        run: ./vcpkg/vcpkg install ogre:x64-linux bullet3:x64-linux boost:x64-linux pugixml:x64-linux 
 
       - name: Generate Ninja build files
         run: cmake -G Ninja -B build -DCI=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration == 'Release' && 'MinSizeRel' || matrix.configuration }} -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake  .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(Boost REQUIRED)
 find_package(OGRE REQUIRED COMPONENTS Bites CONFIG)
 find_package(pugixml REQUIRED)
 find_package(Bullet CONFIG REQUIRED)
-set(RNR_BULLET_LIBRARIES LinearMath Bullet3Common BulletDynamics BulletSoftBody BulletCollision BulletInverseDynamics)
+set(RNR_BULLET_LIBRARIES Bullet3Common BulletDynamics BulletSoftBody BulletCollision BulletInverseDynamics LinearMath)
 
 add_subdirectory(Projects)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(RNR_BULLET_LIBRARIES LinearMath Bullet3Common BulletDynamics BulletSoftBody 
 add_subdirectory(Projects)
 
 if(CI AND UNIX)
-    file(COPY ${OGRE_MEDIA_DIR}/ShadowVolume/ DESTINATION ${CMAKE_BINARY_DIR}/shaders)
+    file(COPY ${OGRE_MEDIA_DIR}/Main/ DESTINATION ${CMAKE_BINARY_DIR}/shaders)
     file(COPY ${OGRE_MEDIA_DIR}/RTShaderLib/ DESTINATION ${CMAKE_BINARY_DIR}/shaders)
     file(COPY ${OGRE_PLUGIN_DIR}/ DESTINATION ${CMAKE_BINARY_DIR}/plugins)
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,10 @@
+{
+    "name": "rnr",
+    "version": "1.0.0",
+    "dependencies": [
+        "ogre",
+        "bullet3",
+        "boost",
+        "pugixml"
+    ]
+}


### PR DESCRIPTION
TODO:
- [x] ~~Clone and build OGRE on the workflow (see: https://ogrecave.github.io/ogre/api/latest/building-ogre.html)~~ *(we now use vcpkg)*
- [x] ~~Clone and build Boost on the workflow (or not, since APT provides 1.71; we can use this just fine I think?)~~ *(we now use vcpkg)*
- [ ] Clean up (i.e. remove the OpenGL option from CMake & better method to move executables to packaged/)